### PR TITLE
Rename package to codacy-coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can install the coverage reporter by running:
 
 ### Install python-codacy-coverage
 ```
-pip install python-codacy-coverage
+pip install codacy-coverage
 ```
 
 ## Updating Codacy

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='python-codacy-coverage',
+    name='codacy-coverage',
 
     version='1.0.0',
 


### PR DESCRIPTION
Just a suggestion. This follows the convention used by most Python packages. I left the name of the installed script alone, though it seems a bit wordy.
