### PR TITLE
Fix crash on final message with Python 3

### DIFF
--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -107,7 +107,7 @@ def upload_report(report, token, commit):
     logging.debug(r.content)
     r.raise_for_status()
 
-    message = json.loads(r.content)['success']
+    message = json.loads(r.text)['success']
     logging.info(message)
 
 


### PR DESCRIPTION
With Python 3, the tool crashes after uploading the coverage results with the following message:

```
2015-11-22 16:25:40,601 - INFO - Parsing report file...
2015-11-22 16:25:40,909 - INFO - Uploading report...
2015-11-22 16:25:40,928 - INFO - Starting new HTTPS connection (1): api.codacy.com
Traceback (most recent call last):
  File "/home/wendler/venv/benchexec-src/bin/python-codacy-coverage", line 9, in <module>
    load_entry_point('codacy-coverage==1.1.0', 'console_scripts', 'python-codacy-coverage')()
  File "/home/wendler/venv/benchexec-src/src/codacy/src/codacy/__init__.py", line 6, in main
    return reporter.run()
  File "/home/wendler/venv/benchexec-src/src/codacy/src/codacy/reporter.py", line 140, in run
    upload_report(report, CODACY_PROJECT_TOKEN, args.commit)
  File "/home/wendler/venv/benchexec-src/src/codacy/src/codacy/reporter.py", line 110, in upload_report
    message = json.loads(r.content)['success']
  File "/usr/lib/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```
