### PR TITLE
Fixing bytes-related TypeError upon report uploading when using python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'}, include_package_data=True,
 
-    install_requires=['requests'],
+    install_requires=['requests', 'six'],
 
     extras_require={
         'dev': ['check-manifest'],

--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -6,6 +6,7 @@ import logging
 import os
 from xml.dom import minidom
 import requests
+import six
 
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s - %(levelname)s - %(message)s')
@@ -107,7 +108,10 @@ def upload_report(report, token, commit):
     logging.debug(r.content)
     r.raise_for_status()
 
-    message = json.loads(r.content)['success']
+    if six.PY2:
+        message = json.loads(r.content)['success']
+    else:
+        message = json.loads(str(r.content, 'utf-8'))['success']
     logging.info(message)
 
 


### PR DESCRIPTION
When trying to submit a `coverage.xml` file, under Python 3.5.0 and using a git-installed `codacy-coverage`, the following exception is raised:

```
Traceback (most recent call last):
  File "VENV_PATH/bin/python-codacy-coverage", line 9, in <module>
    load_entry_point('codacy-coverage==1.1.0', 'console_scripts', 'python-codacy-coverage')()
  File "VENV_PATH/lib/python3.5/site-packages/codacy/__init__.py", line 6, in main
    return reporter.run()
  File "VENV_PATH/lib/python3.5/site-packages/codacy/reporter.py", line 140, in run
    upload_report(report, CODACY_PROJECT_TOKEN, args.commit)
  File "VENV_PATH/lib/python3.5/site-packages/codacy/reporter.py", line 110, in upload_report
    message = json.loads(r.content)['success']
  File "/usr/lib64/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

This commit fixes this issue by adding the `six` library as a dependency and implements a different behaviour if Python3 is being used.
