### PR TITLE
Import version instead of reading it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ __version__ = '1.1.1'
 
 # Get the correct version from file
 try:
-    exec(open('version.py').read())
-except:
+    import version
+    __version__ = version.__version__
+except ImportError:
     pass
 
 setup(


### PR DESCRIPTION
PR from the comments on f7e687e.
This fixes the bare except, but doesn't deal with the fact that the module itself still has no `__version__`. I don't know what your build server setup is, maybe it's not worth the trouble to fix that.
