### PR TITLE
Verify the response status from the API

### DIFF
--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -108,8 +108,11 @@ def upload_report(report, token, commit):
     logging.debug(r.content)
     r.raise_for_status()
 
-    message = json.loads(r.text)['success']
-    logging.info(message)
+    response = json.loads(r.text)
+    try:
+        logging.info(response['success'])
+    except KeyError:
+        logging.error(response['error'])
 
 
 def run():


### PR DESCRIPTION
The code was looking blindly in the response from the API leading to a crash if there was an error instead of the expected success.

(FT-1097)
