### PR TITLE
Add --directory override to specify top level git directory.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -20,7 +20,7 @@ class ReporterTests(unittest.TestCase):
             with open(filename) as f:
                 return f.read()
 
-        generated = codacy.reporter.parse_report_file(generated_filename)
+        generated = codacy.reporter.parse_report_file(generated_filename, '')
 
         json_content = file_get_contents(expected_filename)
         expected = json.loads(json_content)


### PR DESCRIPTION
Currently, the coverage reporter invokes git to determine the base
directory of the git repository. If CI is being run inside a docker
container, best practices include not copying the VCS information into
the container to reduce the size. However, if that advice is followed,
the coverage reporter is then unable to invoke git successfully for this
use case.

To support running without git, this adds a command line flag to
manually specify the base directory without invoking git. This has the
side benefit of allowing the coverage reporter to be useful for other
VCS systems as well.
