### PR TITLE
Total percentage should always be an integer

### DIFF
--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -95,7 +95,7 @@ def merge_reports(report_list):
         total_coverages += [fileentry['total']]
 
     # And average
-    final_report['total'] = sum(total_coverages)/len(total_coverages)
+    final_report['total'] = int(sum(total_coverages)/len(total_coverages))
 
     return final_report
 


### PR DESCRIPTION
This resolves Issue #25. When the average report coverage is calculated a float can be returned. If this is the case the API won't process the request as this field is supposed to be an integer. This change makes sure this total percentage is always an integer.
