### PR TITLE
Fix subfolder traversal in 'file_exists'.

### DIFF
--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -55,7 +55,7 @@ def file_exists(rootdir, filename):
             return True
         else:
             for subFolder in subFolders:
-                return file_exists(subFolder, filename)
+                return file_exists(os.path.join(rootdir, subFolder), filename)
             return False
 
 


### PR DESCRIPTION
`file_exists` requires a path and not only the subfolder name.

Right now some files in subfolders won't be found. On Travis this also caused a infinite recursion  