### PR TITLE
Fix reports merge

### DIFF
--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -99,11 +99,12 @@ def merge_and_round_reports(report_list):
             average_sum += file_entry['total'] * file_entry['codeLines']
             total_lines += file_entry['codeLines']
 
-        final_report['total'] = int(floor(average_sum / total_lines))
+        final_report['total'] = average_sum / total_lines
 
     # Round all total values
     for file_entry in final_report['fileReports']:
         file_entry['total'] = int(floor(file_entry['total']))
+    final_report['total'] = int(floor(final_report['total']))
 
     return final_report
 

--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 from xml.dom import minidom
-from math import floor
 
 import requests
 from requests.packages.urllib3 import util as urllib3_util
@@ -104,8 +103,8 @@ def merge_and_round_reports(report_list):
 
     # Round all total values
     for file_entry in final_report['fileReports']:
-        file_entry['total'] = int(floor(file_entry['total']))
-    final_report['total'] = int(floor(final_report['total']))
+        file_entry['total'] = int(file_entry['total'])
+    final_report['total'] = int(final_report['total'])
 
     return final_report
 
@@ -115,7 +114,7 @@ def parse_report_file(report_file, git_directory):
     :param report_file:
     """
 
-    # Convert decimal string to floored decimal percent value
+    # Convert decimal string to decimal percent value
     def percent(s):
         return float(s) * 100
 

--- a/tests/coverage-merge/cobertura.3.xml
+++ b/tests/coverage-merge/cobertura.3.xml
@@ -1,28 +1,32 @@
-<coverage line-rate="0.87">
+<coverage line-rate="0.50">
     <packages>
-        <package line-rate="0.87" name="com.github.codacy">
+        <package line-rate="0.50" name="com.github.codacy">
             <classes>
-                <class line-rate="0.87" name="TestSourceFile" filename="src/test/resources/TestSourceFile.scala">
+                <class line-rate="0.75" name="TestSourceFile1" filename="src/test/resources/TestSourceFile1.scala">
                     <methods/>
                     <lines>
                         <line number="4" hits="1"/>
                         <line number="5" hits="1"/>
-                        <line number="6" hits="2"/>
+                        <line number="6" hits="0"/>
+                        <line number="7" hits="2"/>
                     </lines>
                 </class>
-                <class line-rate="0.87" name="TestSourceFile" filename="src/test/resources/TestSourceFile.scala">
+                <class line-rate="0.6667" name="TestSourceFile2" filename="src/test/resources/TestSourceFile2.scala">
                     <methods/>
                     <lines>
+                        <line number="5" hits="0"/>
                         <line number="9" hits="1"/>
                         <line number="10" hits="1"/>
                     </lines>
                 </class>
-                <class line-rate="0.87" name="TestSourceFile2" filename="src/test/resources/TestSourceFile2.scala">
+                <class line-rate="0.20" name="TestSourceFile3" filename="src/test/resources/TestSourceFile3.scala">
                     <methods/>
                     <lines>
-                        <line number="1" hits="1"/>
+                        <line number="1" hits="0"/>
                         <line number="2" hits="1"/>
-                        <line number="3" hits="1"/>
+                        <line number="3" hits="0"/>
+                        <line number="4" hits="0"/>
+                        <line number="7" hits="0"/>
                     </lines>
                 </class>
             </classes>

--- a/tests/coverage-merge/coverage-merge.json
+++ b/tests/coverage-merge/coverage-merge.json
@@ -1,5 +1,6 @@
 {
   "total": 49,
+  "codeLines": 74,
   "fileReports": [
     {
       "total": 75,

--- a/tests/coverage-merge/coverage-merge.json
+++ b/tests/coverage-merge/coverage-merge.json
@@ -1,34 +1,36 @@
 {
-  "total": 75,
+  "total": 49,
   "fileReports": [
     {
-      "total": 87,
+      "total": 75,
+      "codeLines": 4,
       "coverage": {
-        "5": 1,
         "4": 1,
-        "6": 2
+        "5": 1,
+        "7": 2
       },
-      "filename": "src/test/resources/TestSourceFile.scala"
+      "filename": "src/test/resources/TestSourceFile1.scala"
     },
     {
-      "total": 87,
+      "total": 66,
+      "codeLines": 3,
       "coverage": {
         "9": 1,
         "10": 1
       },
-      "filename": "src/test/resources/TestSourceFile.scala"
-    },
-    {
-      "total": 87,
-      "coverage": {
-        "1": 1,
-        "3": 1,
-        "2": 1
-      },
       "filename": "src/test/resources/TestSourceFile2.scala"
     },
     {
+      "total": 20,
+      "codeLines": 5,
+      "coverage": {
+        "2": 1
+      },
+      "filename": "src/test/resources/TestSourceFile3.scala"
+    },
+    {
       "total": 66,
+      "codeLines": 3,
       "coverage": {
         "1": 1,
         "4": 1
@@ -37,6 +39,7 @@
     },
     {
       "total": 49,
+      "codeLines": 59,
       "coverage": {
         "50": 1,
         "60": 1,

--- a/tests/coverage3/cobertura.xml
+++ b/tests/coverage3/cobertura.xml
@@ -1,28 +1,32 @@
-<coverage line-rate="0.87">
+<coverage line-rate="0.50">
     <packages>
-        <package line-rate="0.87" name="com.github.codacy">
+        <package line-rate="0.50" name="com.github.codacy">
             <classes>
-                <class line-rate="0.87" name="TestSourceFile" filename="src/test/resources/TestSourceFile.scala">
+                <class line-rate="0.75" name="TestSourceFile1" filename="src/test/resources/TestSourceFile1.scala">
                     <methods/>
                     <lines>
                         <line number="4" hits="1"/>
                         <line number="5" hits="1"/>
-                        <line number="6" hits="2"/>
+                        <line number="6" hits="0"/>
+                        <line number="7" hits="2"/>
                     </lines>
                 </class>
-                <class line-rate="0.87" name="TestSourceFile" filename="src/test/resources/TestSourceFile.scala">
+                <class line-rate="0.6667" name="TestSourceFile2" filename="src/test/resources/TestSourceFile2.scala">
                     <methods/>
                     <lines>
+                        <line number="5" hits="0"/>
                         <line number="9" hits="1"/>
                         <line number="10" hits="1"/>
                     </lines>
                 </class>
-                <class line-rate="0.87" name="TestSourceFile2" filename="src/test/resources/TestSourceFile2.scala">
+                <class line-rate="0.20" name="TestSourceFile3" filename="src/test/resources/TestSourceFile3.scala">
                     <methods/>
                     <lines>
-                        <line number="1" hits="1"/>
+                        <line number="1" hits="0"/>
                         <line number="2" hits="1"/>
-                        <line number="3" hits="1"/>
+                        <line number="3" hits="0"/>
+                        <line number="4" hits="0"/>
+                        <line number="7" hits="0"/>
                     </lines>
                 </class>
             </classes>

--- a/tests/coverage3/coverage.json
+++ b/tests/coverage3/coverage.json
@@ -1,31 +1,32 @@
 {
-  "total": 87,
+  "total": 50,
   "fileReports": [
     {
-      "total": 87,
+      "total": 75,
+      "codeLines": 4,
       "coverage": {
-        "5": 1,
         "4": 1,
-        "6": 2
+        "5": 1,
+        "7": 2
       },
-      "filename": "src/test/resources/TestSourceFile.scala"
+      "filename": "src/test/resources/TestSourceFile1.scala"
     },
     {
-      "total": 87,
+      "total": 66,
+      "codeLines": 3,
       "coverage": {
         "9": 1,
         "10": 1
       },
-      "filename": "src/test/resources/TestSourceFile.scala"
+      "filename": "src/test/resources/TestSourceFile2.scala"
     },
     {
-      "total": 87,
+      "total": 20,
+      "codeLines": 5,
       "coverage": {
-        "1": 1,
-        "3": 1,
         "2": 1
       },
-      "filename": "src/test/resources/TestSourceFile2.scala"
+      "filename": "src/test/resources/TestSourceFile3.scala"
     }
   ],
   "language": "python"

--- a/tests/coverage3/coverage.json
+++ b/tests/coverage3/coverage.json
@@ -1,5 +1,6 @@
 {
   "total": 50,
+  "codeLines": 12,
   "fileReports": [
     {
       "total": 75,

--- a/tests/coverage4/coverage.json
+++ b/tests/coverage4/coverage.json
@@ -3,6 +3,7 @@
   "fileReports": [
     {
       "total": 66,
+      "codeLines": 3,
       "coverage": {
         "1": 1,
         "4": 1
@@ -11,6 +12,7 @@
     },
     {
       "total": 49,
+      "codeLines": 59,
       "coverage": {
         "50": 1,
         "60": 1,

--- a/tests/coverage4/coverage.json
+++ b/tests/coverage4/coverage.json
@@ -1,5 +1,6 @@
 {
   "total": 50,
+  "codeLines": 62,
   "fileReports": [
     {
       "total": 66,

--- a/tests/filepath/coverage.json
+++ b/tests/filepath/coverage.json
@@ -3,6 +3,7 @@
   "fileReports": [
     {
       "total": 66,
+      "codeLines": 3,
       "coverage": {
         "1": 1,
         "4": 1
@@ -11,6 +12,7 @@
     },
     {
       "total": 49,
+      "codeLines": 59,
       "coverage": {
         "50": 1,
         "60": 1,

--- a/tests/filepath/coverage.json
+++ b/tests/filepath/coverage.json
@@ -1,5 +1,6 @@
 {
   "total": 50,
+  "codeLines": 62,
   "fileReports": [
     {
       "total": 66,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,8 @@
-
 import json
 import os
 import unittest
 
 import codacy.reporter
-
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -14,7 +12,6 @@ def _file_location(*args):
 
 
 class ReporterTests(unittest.TestCase):
-
     def compare_parse_result(self, generated, expected_filename):
         def file_get_contents(filename):
             with open(filename) as f:
@@ -28,41 +25,47 @@ class ReporterTests(unittest.TestCase):
     def test_parser_coverage3(self):
         self.maxDiff = None
 
-        generated = codacy.reporter.parse_report_file(
+        parsed = codacy.reporter.parse_report_file(
             _file_location('coverage3', 'cobertura.xml'), '')
-        self.compare_parse_result(generated,
+
+        rounded = codacy.reporter.merge_and_round_reports([parsed])
+
+        self.compare_parse_result(rounded,
                                   _file_location('coverage3', 'coverage.json'))
 
     def test_parser_coverage4(self):
         self.maxDiff = None
 
-        generated = codacy.reporter.parse_report_file(
+        parsed = codacy.reporter.parse_report_file(
             _file_location('coverage4', 'cobertura.xml'), '')
-        self.compare_parse_result(generated,
+
+        rounded = codacy.reporter.merge_and_round_reports([parsed])
+
+        self.compare_parse_result(rounded,
                                   _file_location('coverage4', 'coverage.json'))
 
     def test_parser_git_filepath(self):
         self.maxDiff = None
 
-        generated = codacy.reporter.parse_report_file(
+        parsed = codacy.reporter.parse_report_file(
             _file_location('filepath', 'cobertura.xml.tpl'), '')
 
-        self.compare_parse_result(generated,
+        rounded = codacy.reporter.merge_and_round_reports([parsed])
+
+        self.compare_parse_result(rounded,
                                   _file_location('filepath', 'coverage.json'))
 
     def test_merge(self):
         self.maxDiff = None
-        
+
         generated3 = codacy.reporter.parse_report_file(
             _file_location('coverage-merge', 'cobertura.3.xml'), '')
         generated4 = codacy.reporter.parse_report_file(
             _file_location('coverage-merge', 'cobertura.4.xml'), '')
 
-        result = codacy.reporter.merge_reports([generated3, generated4])
+        result = codacy.reporter.merge_and_round_reports([generated3, generated4])
 
         self.compare_parse_result(result, _file_location('coverage-merge', 'coverage-merge.json'))
-		
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The coverage average was not weighted based on the number of line on each file, meaning that small files had the same weight (when calculating the average) as bigger files.