### PR TITLE
fix file_exists

### DIFF
--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -47,13 +47,7 @@ def get_git_directory():
 
 
 def file_exists(rootdir, filename):
-    for root, subFolders, files in os.walk(rootdir):
-        if filename in files:
-            return True
-        else:
-            for subFolder in subFolders:
-                return file_exists(os.path.join(rootdir, subFolder), filename)
-            return False
+    return os.path.exists(os.path.join(rootdir, filename))
 
 
 def generate_filename(sources, filename, git_directory):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,18 @@
 import json
 import os
 import unittest
+import sys
 
 import codacy.reporter
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+
+print("PYTHON_VERSION: ", sys.version_info)
+
+if sys.version_info[0] == 3:
+    unicode_type = str
+else:
+    unicode_type = unicode
 
 
 def _file_location(*args):
@@ -22,7 +30,7 @@ class ReporterTests(unittest.TestCase):
                 result = {}
                 for key, value in d.items():
                     result[to_utf8(key)] = to_utf8(value)
-            elif type(d) is unicode:
+            elif type(d) is unicode_type:
                 return d.encode('utf8')
             else:
                 return d


### PR DESCRIPTION
When having a `filename=foo/bar/baz` it would never be matched in `files` produced by os.walk.

I just used os.path.exists, tests pass. 


There [is a an issue with py350 in tox config](https://github.com/codacy/python-codacy-coverage/issues/37) though.