### PR TITLE
Allow running codacy from python using the `-m` flag

### DIFF
--- a/src/codacy/__main__.py
+++ b/src/codacy/__main__.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#!/usr/bin/env python
 from __future__ import absolute_import
 
 import sys

--- a/src/codacy/__main__.py
+++ b/src/codacy/__main__.py
@@ -1,0 +1,8 @@
+#/usr/bin/env python
+from __future__ import absolute_import
+
+import sys
+from . import __name__
+from .reporter import run
+
+sys.exit(run(__name__))

--- a/src/codacy/reporter.py
+++ b/src/codacy/reporter.py
@@ -164,8 +164,8 @@ def upload_report(report, token, commit):
         logging.error(response['error'])
 
 
-def run():
-    parser = argparse.ArgumentParser(description='Codacy coverage reporter for Python.')
+def run(prog=None):
+    parser = argparse.ArgumentParser(prog=prog, description='Codacy coverage reporter for Python.')
     parser.add_argument("-r", "--report", help="coverage report file",
                         default=[], type=str,
                         action='append')


### PR DESCRIPTION
Hi there,

I just added a `__main__.py` file to allow running the program from Python directly instead of using an entry point (`python -m codacy`). The main perk is that it is not needed for `python-codacy-coverage` to be in `$PATH` anymore to be able to report coverage, but only for `codacy` to be in `$PYTHONPATH`. This makes it easier for some CI environments.

I also added a `prog` parameter to `runner.run` so that the program name can be changed: this way, instead of having `python -m codacy -h` display this:
```
usage: __main__.py [-h] [-r REPORT] [-c COMMIT] [-t TOKEN] [-d DIRECTORY] [-v]
```
it show this:
```
usage: codacy [-h] [-r REPORT] [-c COMMIT] [-t TOKEN] [-d DIRECTORY] [-v]
```
while `python-codacy-coverage -h` will show:
```
usage: python-codacy-coverage [-h] [-r REPORT] [-c COMMIT] [-t TOKEN] [-d DIRECTORY] [-v]
```
